### PR TITLE
Bug fixes, updates, and new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,90 @@
+NAME
+    Games::Dice - Perl module to simulate die rolls
+
+VERSION
+    version 0.046
+
+SYNOPSIS
+      use Games::Dice 'roll';
+      $strength = roll '3d6+1';
+
+      use Games::Dice 'roll_array';
+      @rolls = roll_array '4d8';
+
+DESCRIPTION
+    Games::Dice simulates die rolls. It uses a function-oriented (not
+    object-oriented) interface. No functions are exported by default. At
+    present, there are two functions which are exportable: "roll" and
+    "roll_array". The latter is used internally by "roll", but can also be
+    exported by itself.
+
+    The number and type of dice to roll is given in a style which should be
+    familiar to players of popular role-playing games: *a*d*b*[+-*/b]*c*.
+    *a* is optional and defaults to 1; it gives the number of dice to roll.
+    *b* indicates the number of sides to each die; the most common,
+    cube-shaped die is thus a d6. % can be used instead of 100 for *b*;
+    hence, rolling 2d% and 2d100 is equivalent. If F is used for *b* fudge
+    dice are used, which either results in -1, 0 or 1. "roll" simulates *a*
+    rolls of *b*-sided dice and adds together the results. The optional end,
+    consisting of one of +-*/b and a number *c*, can modify the sum of the
+    individual dice. +-*/ are similar in that they take the sum of the rolls
+    and add or subtract *c*, or multiply or divide the sum by *c*. (x can
+    also be used instead of *.) Hence, 1d6+2 gives a number in the range
+    3..8, and 2d4*10 gives a number in the range 20..80. (Using / truncates
+    the result to an int after dividing.) Using b in this slot is a little
+    different: it's short for "best" and indicates "roll a number of dice,
+    but add together only the best few". For example, 5d6b3 rolls five six-
+    sided dice and adds together the three best rolls. This is sometimes
+    used, for example, in role-playing to give higher averages. Likewise
+    using 'w' in this slot is short for "worst" and indicates "roll a number
+    of dice, but add together only the worst few". For example 2d20w1 rolls
+    two twenty-sided dice and returns the worst (lower) of the two rolls.
+    This is sometimes used in role playing games to do a "roll with
+    disadvantage" where you roll twice and take the lower of the two rolls.
+
+    Generally, "roll" probably provides the nicer interface, since it does
+    the adding up itself. However, in some situations one may wish to
+    process the individual rolls (for example, I am told that in the game
+    Feng Shui, the number of dice to be rolled cannot be determined in
+    advance but depends on whether any 6s were rolled); in such a case, one
+    can use "roll_array" to return an array of values, which can then be
+    examined or processed in an application-dependent manner.
+
+    This having been said, comments and additions (especially if accompanied
+    by code!) to Games::Dice are welcome. So, using the above example, if
+    anyone wishes to contribute a function along the lines of roll_feng_shui
+    to become part of Games::Dice (or to support any other style of die
+    rolling), you can contribute it to the author's address, listed below.
+
+PERL VERSION
+    This module should work on any version of perl still receiving updates
+    from the Perl 5 Porters. This means it should work on any version of
+    perl released in the last two to three years. (That is, if the most
+    recently released version is v5.40, then this module should work on both
+    v5.40 and v5.38.)
+
+    Although it may work on older versions of perl, no guarantee is made
+    that the minimum required version will not be increased. The version may
+    be increased for any reason, and there is no promise that patches will
+    be accepted to lower the minimum required perl.
+
+NAME
+AUTHORS
+    *   Philip Newton <pne@cpan.org>
+
+    *   Ricardo Signes <cpan@semiotic.systems>
+
+CONTRIBUTORS
+    *   Mario Domgoergen <mdom@taz.de>
+
+    *   Mark Allen <mrallen1@yahoo.com>
+
+    *   Ricardo Signes <rjbs@semiotic.systems>
+
+COPYRIGHT AND LICENSE
+    This software is Copyright (c) 1999 by Philip Newton.
+
+    This is free software, licensed under:
+
+      The MIT (X11) License
+

--- a/lib/Games/Dice.pm
+++ b/lib/Games/Dice.pm
@@ -11,10 +11,6 @@ our @EXPORT_OK = qw( roll roll_array);
 
 # Preloaded methods go here.
 
-# Win32 has crummy built in rand() support
-# So let's use something that's decent and pure perl
-use if $^O eq "MSWin32", 'Math::Random::MT::Perl' => qw(rand);
-
 sub _parse_spec {
     my $line = shift;
     return undef unless $line =~ m{

--- a/lib/Games/Dice.pm
+++ b/lib/Games/Dice.pm
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use 5.010;
-package Games::Dice;
+package Games::Dice 0.050;
 # ABSTRACT: Perl module to simulate die rolls
 
 require Exporter;
@@ -26,12 +26,12 @@ sub _parse_spec {
                       \d+          # either one or more digits
                     |              # or
                       %            # a percent sign for d% = d100
-                    |              # pr
-                      F            # a F for a fudge dice
+                    |              # or
+                      F|f          # a F for a fudge dice
                    )
                  )
                  (?:               # grouping-only parens
-                   (?<sign>[-+xX*/bB])  # a + - * / b(est) in $2
+                   (?<sign>[-+xX*/bBwW])  # a + - * / b(est) w(orst) in $2
                    (?<offset>\d+)  # an offset in $3
                  )?                # both of those last are optional
                  \s*               # possibly some trailing space (like \n)
@@ -72,6 +72,13 @@ sub roll ($) {
         @throws = sort { $b <=> $a } @throws;  # sort numerically, descending
         @result = @throws[ 0 .. $offset - 1 ]; # pick off the $offset first ones
     }
+    elsif ( $sign eq 'w' ) {
+        $offset = 0       if $offset < 0;
+        $offset = @throws if $offset > @throws;
+
+        @throws = sort { $a <=> $b } @throws;  # sort numerically, ascending
+        @result = @throws[ 0 .. $offset - 1 ]; # pick off the $offset first ones
+    }
     else {
         @result = @throws;
     }
@@ -96,7 +103,7 @@ sub _roll_dice {
     if ( $type eq '%' ) {
         $type = 100;
     }
-    elsif ( $type eq 'F' ) {
+    elsif ( uc $type eq 'F' ) {
         $throw = sub { int( rand 3 ) - 1 };
     }
 
@@ -119,10 +126,18 @@ sub roll_array ($) {
 }
 
 1;
-__END__
+
+=pod
+
+=encoding UTF-8
 
 =head1 NAME
 
+Games::Dice - Perl module to simulate die rolls
+
+=head1 VERSION
+
+version 0.050
 
 =head1 SYNOPSIS
 
@@ -157,7 +172,12 @@ the result to an int after dividing.) Using b in this slot is a little
 different: it's short for "best" and indicates "roll a number of dice,
 but add together only the best few". For example, 5d6b3 rolls five six-
 sided dice and adds together the three best rolls. This is sometimes
-used, for example, in role-playing to give higher averages.
+used, for example, in role-playing to give higher averages. Likewise
+using 'w' in this slot is short for "worst" and indicates "roll a number
+of dice, but add together only the worst few". For example 2d20w1 rolls two
+twenty-sided dice and returns the worst (lower) of the two rolls. This is
+sometimes used in role playing games to do a "roll with disadvantage"
+where you roll twice and take the lower of the two rolls.
 
 Generally, C<roll> probably provides the nicer interface, since it does
 the adding up itself. However, in some situations one may wish to
@@ -173,4 +193,62 @@ anyone wishes to contribute a function along the lines of roll_feng_shui
 to become part of Games::Dice (or to support any other style of die
 rolling), you can contribute it to the author's address, listed below.
 
+=head1 PERL VERSION
+
+This module should work on any version of perl still receiving updates from
+the Perl 5 Porters.  This means it should work on any version of perl released
+in the last two to three years.  (That is, if the most recently released
+version is v5.40, then this module should work on both v5.40 and v5.38.)
+
+Although it may work on older versions of perl, no guarantee is made that the
+minimum required version will not be increased.  The version may be increased
+for any reason, and there is no promise that patches will be accepted to lower
+the minimum required perl.
+
+=head1 NAME
+
+=head1 AUTHORS
+
+=over 4
+
+=item *
+
+Philip Newton <pne@cpan.org>
+
+=item *
+
+Ricardo Signes <cpan@semiotic.systems>
+
+=back
+
+=head1 CONTRIBUTORS
+
+=for stopwords Mario Domgoergen Mark Allen Ricardo Signes
+
+=over 4
+
+=item *
+
+Mario Domgoergen <mdom@taz.de>
+
+=item *
+
+Mark Allen <mrallen1@yahoo.com>
+
+=item *
+
+Ricardo Signes <rjbs@semiotic.systems>
+
+=back
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is Copyright (c) 1999 by Philip Newton.
+
+This is free software, licensed under:
+
+  The MIT (X11) License
+
 =cut
+
+__END__

--- a/t/basic.t
+++ b/t/basic.t
@@ -18,10 +18,11 @@ is( roll('2d6*2'), 16, 'roll 2d6*2 - basic roll with multiplier and * sign' );
 is( roll('2d6x2'), 16, 'roll 2d6x2 - basic roll with multiplier and x sign' );
 is( roll('2d6/2'),  4, 'roll 2d6/2 - basic roll with multiplier and / sign' );
 
-srand( oneish(), oneish(), oneish, oneish );
+srand( oneish(), oneish(), oneish(), oneish() );
 
 is( roll('4dF'), 4,  'roll 4dF - fudge rolls with only +' );
 is( roll('4dF'), -4, 'roll 4dF - fudge rolls with only -' );
+is( roll('4df'), -4, 'roll 4df - fudge rolls using "f" with only -' );
 
 srand(0.5);
 is( roll('d%'), 51, 'roll d% - % as alias for 100' );
@@ -31,5 +32,8 @@ is( roll('5d6b3'), 10, 'roll 5d6b3 - best 3 out of 5' );
 
 srand( 0.5, 0.1, 0.8 );
 is( roll('5d6b6'), 12, 'roll 5d6b6 - best 6 out of 5' );
+
+srand( 0.5, 0.1, 0.8 );
+is( roll('5d6w3'), 3, 'roll 5d6w3 - worst 3 out of 5' );
 
 done_testing();


### PR DESCRIPTION
I split these up so you could pull whichever pieces you felt were appropriate.

I added support for the 'worst' rolls, parallel to the 'best' option. In games like D&D there are "roll with advantage" and "roll with disadvantage" which take the 'best' or 'worst' dice rolls from a set. So an attack roll with advantage would be 2d20b1 and a roll with disadvantage would be 2d20w1. It seemed appropriate to have a parallel to the 'best' option.

I added support for lowercase 'f' as a dice type for fudge dice. The original code only had uppercase F.

I changed the version to 0.50 (was 0.46).

I imported the perldoc info from the currently deployed version of dice.pm in CPAN. Added a small bit about the 'worst' option.

I removed the special substitute random number generator when you are running under windows because this problem has been fixed for several years now. See https://github.com/perl/perl5/issues/12620

I added a test case for the new 'worst' modifier and fixed a couple of bugs in the test code (uses of oneish without parens). I also added a test case for the lowercase 'f' fudge dice type.

I added a readme.md that is just the output of perldoc for the module.